### PR TITLE
Problem: Retries can perform poorly under high contention.

### DIFF
--- a/extensions/omni_txn/migrate/2_retry.sql
+++ b/extensions/omni_txn/migrate/2_retry.sql
@@ -1,9 +1,9 @@
-create procedure retry(stmts text, max_attempts int default 10, repeatable_read boolean default false)
+create procedure retry(stmts text, max_attempts int default 10, repeatable_read boolean default false, gather_backoff_values boolean default false)
     language c as
 'MODULE_PATHNAME';
 
 comment on procedure retry is $$
-Retry serializable transaction on statements `stmts`, `max_attempt` number of times (10 by default)
+Retry serializable transaction on statements `stmts`, `max_attempt` number of times (10 by default). `gather_backoff_values` controls if the backoff values used for sleeping will be recorded for debugging/testing purposes (false in orded to increase performance)
 $$;
 
 create function current_retry_attempt()
@@ -13,4 +13,18 @@ create function current_retry_attempt()
 
 comment on function current_retry_attempt() is $$
 Within `omni_txn.retry` indicates the current retry attempt. Zero during the first run.
+$$;
+
+create function retry_backoff_values()
+    returns table
+            (
+              backoff_sleep_time int
+            )
+    volatile
+    language c
+as
+'MODULE_PATHNAME';
+
+comment on function retry_backoff_values () is $$
+Retrieves the backoff values used in the `omni_txn.retry` run. Empty in the first run.
 $$;

--- a/extensions/omni_txn/omni_txn.c
+++ b/extensions/omni_txn/omni_txn.c
@@ -9,10 +9,50 @@
 #if PG_MAJORVERSION_NUM < 15
 #include <access/xact.h>
 #endif
+#include <common/pg_prng.h>
+#include <nodes/pg_list.h>
+#include <utils/memutils.h>
 
 PG_MODULE_MAGIC;
 
+static List *backoff_values;
 static int32 retry_attempts = 0;
+static int64 cap_sleep_microsecs = 10000;
+static int64 base_sleep_microsecs = 1;
+
+/**
+ * The backoff should increase with each attempt.
+ */
+static int64 get_backoff(int64 cap, int64 base, int32 attempt) {
+  int exp = Min(attempt, 30); // caps the exponent to avoid overflowing,
+                              // as the user can control the # of
+                              // attempts.
+  return Min(cap, base * (1 << exp));
+}
+
+/**
+ * Get the random jitter to avoid contention in the backoff. Uses the
+ * process seed initialized in `InitProcessGlobals`.
+ */
+static float8 get_jitter() { return pg_prng_double(&pg_global_prng_state); }
+
+/**
+ * Implements the backoff + fitter approach
+ * https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
+ */
+static int64 backoff_jitter(int64 cap, int64 base, int32 attempt) {
+  int64 ret = (int64)(get_jitter() * get_backoff(cap, base, attempt));
+  return (ret > 0 ? ret : 1);
+}
+
+/**
+ * Turns the value into something that can be consumed by
+ * `pg_sleep`. The literal comes copied from there, to ensure the same
+ * ratio.
+ */
+static float8 to_secs(int64 secs) {
+  return (float8)secs/1000000.0;
+}
 
 PG_FUNCTION_INFO_V1(retry);
 
@@ -27,17 +67,26 @@ Datum retry(PG_FUNCTION_ARGS) {
   if (!PG_ARGISNULL(1)) {
     max_attempts = PG_GETARG_INT32(1);
   }
+  bool gather_backoff_values = false;
+  if (!PG_ARGISNULL(2)) {
+    gather_backoff_values = PG_GETARG_BOOL(2);
+  }
 
+  if (gather_backoff_values){
+    // make sure that we are not collecting backoff values from another
+    // transaction. Frees up existing memory in order not to leak it from
+    // existing calls.
+    list_free(backoff_values);
+    backoff_values = NIL;
+  }
   text *stmts = PG_GETARG_TEXT_PP(0);
   char *cstmts = text_to_cstring(stmts);
-
   bool retry = true;
   retry_attempts = 0;
   while (retry) {
     XactIsoLevel =
         (!PG_ARGISNULL(2) && PG_GETARG_BOOL(2)) ? XACT_REPEATABLE_READ : XACT_SERIALIZABLE;
     SPI_connect_ext(SPI_OPT_NONATOMIC);
-
     MemoryContext current_mcxt = CurrentMemoryContext;
     PG_TRY();
     {
@@ -52,17 +101,36 @@ Datum retry(PG_FUNCTION_ARGS) {
       ErrorData *err = CopyErrorData();
       if (err->sqlerrcode == ERRCODE_T_R_SERIALIZATION_FAILURE) {
         ereport(NOTICE, errmsg("%d", max_attempts));
-        if (++retry_attempts > max_attempts) {
+        if (++retry_attempts <= max_attempts) {
+          int64 backoff_with_jitter_in_microsecs =
+              backoff_jitter(cap_sleep_microsecs, base_sleep_microsecs, retry_attempts);
+
+          if (gather_backoff_values) {
+            // make sure to store the backoff values in a way that
+            // survives the end of the transaction so that the user can
+            // call `retry_backoff_values` to retrieve the values for
+            // debugging/testing of the backoff process itself.
+            MemoryContextSwitchTo(TopMemoryContext);
+            backoff_values = lappend_int(backoff_values, backoff_with_jitter_in_microsecs);
+            // go back to the context where we were
+            MemoryContextSwitchTo(current_mcxt);
+          }
+          // abort current transaction
+          PopActiveSnapshot();
+          AbortCurrentTransaction();
+          // backoff a little to avoid contention
+          // add to list
+          DirectFunctionCall1(pg_sleep, Float8GetDatum(to_secs(backoff_with_jitter_in_microsecs)));
+          // start a new transaction
+          SetCurrentStatementStartTimestamp();
+          StartTransactionCommand();
+          PushActiveSnapshot(GetTransactionSnapshot());
+
+        } else {
+          // abort the attempt to run the code.
           ereport(ERROR, errcode(err->sqlerrcode),
                   errmsg("maximum number of retries (%d) has been attempted", max_attempts));
         }
-        PopActiveSnapshot();
-        AbortCurrentTransaction();
-
-        SetCurrentStatementStartTimestamp();
-        StartTransactionCommand();
-        PushActiveSnapshot(GetTransactionSnapshot());
-
       } else {
         retry_attempts = 0;
         PG_RE_THROW();
@@ -80,3 +148,34 @@ Datum retry(PG_FUNCTION_ARGS) {
 PG_FUNCTION_INFO_V1(current_retry_attempt);
 
 Datum current_retry_attempt(PG_FUNCTION_ARGS) { PG_RETURN_INT32(retry_attempts); }
+
+
+PG_FUNCTION_INFO_V1(retry_backoff_values);
+
+/**
+ * Returns the accumulated backoff values, in microseconds.
+ */
+Datum retry_backoff_values(PG_FUNCTION_ARGS) {
+  ReturnSetInfo *rsinfo = (ReturnSetInfo *)fcinfo->resultinfo;
+  rsinfo->returnMode = SFRM_Materialize;
+
+  MemoryContext per_query_ctx = rsinfo->econtext->ecxt_per_query_memory;
+  MemoryContext oldcontext = MemoryContextSwitchTo(per_query_ctx);
+
+  Tuplestorestate *tupstore = tuplestore_begin_heap(false, false, work_mem);
+  rsinfo->setResult = tupstore;
+
+  const ListCell *backoff_value_node;
+  foreach (backoff_value_node, backoff_values) {
+    int64 backoff_value_content = lfirst_int(backoff_value_node);
+    Datum values[1] = {Int64GetDatumFast(backoff_value_content)};
+    bool isnull[1] = {false};
+    tuplestore_putvalues(tupstore, rsinfo->expectedDesc, values, isnull);
+  }
+
+
+  tuplestore_donestoring(tupstore);
+
+  MemoryContextSwitchTo(oldcontext);
+  PG_RETURN_NULL();
+}

--- a/extensions/omni_txn/tests/retry.yml
+++ b/extensions/omni_txn/tests/retry.yml
@@ -128,3 +128,24 @@ tests:
     transaction: false
     error: maximum number of retries (0) has been attempted
   - rollback
+
+- name: backoff values
+  transaction: false
+  tests:
+  - query: |
+      call omni_txn.retry($$select quantity from inventory where product_name = 'Widget';
+      select call_other_session() where omni_txn.current_retry_attempt() < 10;
+      update inventory set quantity = quantity + 20 where product_name = 'Widget';
+      $$, 10, true);
+    transaction: false
+  - query: |
+      select count(*) = 10 as "count",
+             max(amount) < 10000 as "max",
+             min(amount) >= 1 as "min",
+             avg(amount) > 1 as "avg" -- everything as 1 should indicate some underlying error. Highly unlikely to ever happen by itself.
+      from omni_txn.retry_backoff_values() as amount;
+    results:
+      - count: true
+        max: true
+        min:  true
+        avg: true

--- a/extensions/omni_txn/tests/retry_repeatable_read.yml
+++ b/extensions/omni_txn/tests/retry_repeatable_read.yml
@@ -21,7 +21,7 @@ instance:
     $$
     begin
         perform dblink_exec('another_session',
-                            'call omni_txn.retry($other$update inventory set quantity = quantity - 10$other$, repeatable_read => true)');
+                            'call omni_txn.retry($other$update inventory set quantity = quantity - 10$other$, repeatable_read => true, gather_backoff_values => false)');
         return;
     end;
     $$
@@ -41,7 +41,7 @@ tests:
       select call_other_session() where omni_txn.current_retry_attempt() = 0;
       update inventory set quantity = quantity + 20 where product_name = 'Widget';
       insert into retries (count, iso_level) select omni_txn.current_retry_attempt(), current_setting('transaction_isolation');
-      $$, repeatable_read => true);
+      $$, repeatable_read => true, gather_backoff_values => false);
     transaction: false
   - query: select quantity
            from inventory


### PR DESCRIPTION
> The simplest of these contention cases is when a whole lot of clients
> start at the same time, and try to update the same database row. With
> one client guaranteed to succeed every round, the time to complete all
> the updates grows linearly with contention ... N clients compete in
> the first round, N-1 in the second round, and so on. Having every
> client compete in every round is wasteful. [1]

Solution: Add backoff with jitter to spread the calls over time, minimizing contention.

[1] https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/