### PR TITLE
First draft for horizontal filtering.

### DIFF
--- a/extensions/omni_rest/src/postgrest_get.sql
+++ b/extensions/omni_rest/src/postgrest_get.sql
@@ -135,6 +135,11 @@ $$
         'operator', 'and'
         , 'operands', coalesce(jsonb_agg(
           case
+            when key = 'and' then
+              jsonb_build_object(
+                'operator', 'and'
+                , 'operands', omni_rest.postgrest_parse_logical(value)
+              )
             when key = 'or' then
               jsonb_build_object(
                 'operator', 'or'

--- a/extensions/omni_rest/src/postgrest_get.sql
+++ b/extensions/omni_rest/src/postgrest_get.sql
@@ -105,10 +105,17 @@ begin
       columns.param, 
       case split_part(values.param, '.', 1) 
       when 'eq' THEN '=' 
+      when 'neq' THEN '<>' 
+      when 'isdistinct' THEN 'is distinct from ' 
       when 'gt' THEN '>' 
       when 'lt' THEN '<' 
       when 'gte' THEN '>=' 
       when 'lte' THEN '<=' 
+      when 'like' THEN 'like' 
+      when 'ilike' THEN 'ilike' 
+      when 'match' THEN '~' 
+      when 'imatch' THEN '~*' 
+
       end as operator, 
       split_part(values.param, '.', 2) as value
     from 

--- a/extensions/omni_rest/src/postgrest_get.sql
+++ b/extensions/omni_rest/src/postgrest_get.sql
@@ -1,29 +1,43 @@
-create function postgrest_convert_operator(operator_name text)
-  returns text
-  immutable
-  language sql as
-$$
-  select
-      case operator_name
-        when 'eq' THEN '=' 
-        when 'neq' THEN '<>' 
-        when 'isdistinct' THEN 'is distinct from ' 
-        when 'gt' THEN '>' 
-        when 'lt' THEN '<' 
-        when 'gte' THEN '>=' 
-        when 'lte' THEN '<=' 
-        when 'like' THEN 'like' 
-        when 'ilike' THEN 'ilike' 
-        when 'match' THEN '~' 
-        when 'imatch' THEN '~*'
-        when 'not' THEN 'not'
-      end;
+create function postgrest_convert_operator (operator_name text)
+    returns text immutable
+    language sql
+    as $$
+    select
+        case operator_name
+        when 'eq' then
+            '='
+        when 'neq' then
+            '<>'
+        when 'isdistinct' then
+            'is distinct from '
+        when 'gt' then
+            '>'
+        when 'lt' then
+            '<'
+        when 'gte' then
+            '>='
+        when 'lte' then
+            '<='
+        when 'like' then
+            'like'
+        when 'ilike' then
+            'ilike'
+        when 'match' then
+            '~'
+        when 'imatch' then
+            '~*'
+        when 'not' then
+            'not'
+        end;
 $$;
 
-create or replace function postgrest_parse_logical(input text)
-returns jsonb language plpgsql as $$
+create or replace function postgrest_parse_logical (input text)
+    returns jsonb
+    language plpgsql
+    as $$
 declare
-    result jsonb := '[]'; -- initialize an empty json array
+    result jsonb := '[]';
+    -- initialize an empty json array
     current text := '';
     current_production text := '';
     depth int := 0;
@@ -32,65 +46,44 @@ declare
 begin
     -- no nesting, just split and return
     if input !~ '[()]' then
-      select jsonb_agg(
-        jsonb_build_object(
-          'operator'
-          , omni_rest.postgrest_convert_operator(split_part(term, '.', 2))
-          , 'operands'
-          , jsonb_build_array(split_part(term, '.', 1), split_part(term, '.', 3))
-        )
-      ) from unnest(string_to_array(input, ',')) term
-      into result;
-      return result;
+        select
+            jsonb_agg(jsonb_build_object('operator', omni_rest.postgrest_convert_operator (split_part(term, '.', 2)), 'operands', jsonb_build_array(split_part(term, '.', 1), split_part(term, '.', 3))))
+        from
+            unnest(string_to_array(input, ',')) term into result;
+        return result;
     end if;
-
     -- iterate through the string character by character
     foreach token in array regexp_split_to_array(input, '')
     loop
         if token = '(' then
             if depth > 0 then
-              current := current || token;
+                current := current || token;
             end if;
             depth := depth + 1;
         elsif token = ')' then
             depth := depth - 1;
             if depth > 0 then
-              current := current || token;
+                current := current || token;
             end if;
-
             -- if we finish a nested expression, process it
             if depth = 0 then
-                result := 
-                    result || case lower(current_production)
-                        when '' then omni_rest.postgrest_parse_logical(current) 
-                        when 'not.and' then jsonb_build_object(
-                          'operator'
-                          , 'not'
-                          , 'operands'
-                          , jsonb_build_array(jsonb_build_object('operator', 'and', 'operands',omni_rest.postgrest_parse_logical(current)))
-                        )
-                        when 'not' then jsonb_build_object(
-                          'operator'
-                          , 'not'
-                          , 'operands'
-                          , omni_rest.postgrest_parse_logical(current)
-                        )
-                    end;
+                result := result || case lower(current_production)
+                when '' then
+                    omni_rest.postgrest_parse_logical (current)
+                when 'not.and' then
+                    jsonb_build_object('operator', 'not', 'operands', jsonb_build_array(jsonb_build_object('operator', 'and', 'operands', omni_rest.postgrest_parse_logical (current))))
+                when 'not' then
+                    jsonb_build_object('operator', 'not', 'operands', omni_rest.postgrest_parse_logical (current))
+                end;
                 current := '';
             end if;
         elsif depth > 0 then
             current := current || token;
         end if;
-
         if depth = 0 then
             if token = ',' then
                 if current_production !~ '[()]' then
-                    result := result || jsonb_build_array(jsonb_build_object(
-                      'operator'
-                      , omni_rest.postgrest_convert_operator(split_part(current_production, '.', 2))
-                      , 'operands'
-                      , jsonb_build_array(split_part(current_production, '.', 1), split_part(current_production, '.', 3))
-                    ));
+                    result := result || jsonb_build_array(jsonb_build_object('operator', omni_rest.postgrest_convert_operator (split_part(current_production, '.', 2)), 'operands', jsonb_build_array(split_part(current_production, '.', 1), split_part(current_production, '.', 3))));
                 end if;
                 current_production := '';
             else
@@ -99,141 +92,88 @@ begin
         end if;
     end loop;
     if current_production !~ '[()]' then
-        result := result || jsonb_build_array(jsonb_build_object(
-          'operator'
-          , omni_rest.postgrest_convert_operator(split_part(current_production, '.', 2))
-          , 'operands'
-          , jsonb_build_array(split_part(current_production, '.', 1), split_part(current_production, '.', 3))
-        ));
+        result := result || jsonb_build_array(jsonb_build_object('operator', omni_rest.postgrest_convert_operator (split_part(current_production, '.', 2)), 'operands', jsonb_build_array(split_part(current_production, '.', 1), split_part(current_production, '.', 3))));
     end if;
-
     return result;
 end;
 $$;
 
-create function postgrest_parse_get_param(params text[]) 
-    returns jsonb 
-    immutable
-    language sql as 
-$$
+create function postgrest_parse_get_param (params text[])
+    returns jsonb immutable
+    language sql
+    as $$
     with indexed_params as (
-      select * 
-      from unnest(params) with ordinality r(param,index)
-    ),
-    comparisons as (
-    select 
-      lower(columns.param) as key, 
-      values.param as value,
-      omni_rest.postgrest_convert_operator(split_part(values.param, '.', 1)) as first_operator,
-      omni_rest.postgrest_convert_operator(split_part(values.param, '.', 2)) as second_operator
-    from 
-      indexed_params columns 
-      join indexed_params values on columns.index % 2 = 1 and values.index % 2 = 0 and columns.index = values.index - 1
-    )
-    select 
-      jsonb_build_object(
-        'operator', 'and'
-        , 'operands', coalesce(jsonb_agg(
-          case
-            when key = 'not.and' then
-              jsonb_build_object(
-                'operator', 'not'
-                , 'operands', jsonb_build_array( 
-                  jsonb_build_object(
-                    'operator', 'and'
-                    , 'operands', omni_rest.postgrest_parse_logical(value)
-                  )
-                )
-              )
-            when key = 'and' then
-              jsonb_build_object(
-                'operator', 'and'
-                , 'operands', omni_rest.postgrest_parse_logical(value)
-              )
-            when key = 'not.or' then
-              jsonb_build_object(
-                'operator', 'not'
-                , 'operands', jsonb_build_array( 
-                  jsonb_build_object(
-                    'operator', 'or'
-                    , 'operands', omni_rest.postgrest_parse_logical(value)
-                  )
-                )
-              )
-            when key = 'or' then
-              jsonb_build_object(
-                'operator', 'or'
-                , 'operands', omni_rest.postgrest_parse_logical(value)
-              )
-            when first_operator = 'not' then
-              jsonb_build_object(
-                'operator', 'not'
-                , 'operands', jsonb_build_array( 
-                  jsonb_build_object(
-                    'operator', second_operator
-                    , 'operands', jsonb_build_array(key, split_part(value, '.', 3))
-                  )
-                )
-              )
-            when first_operator is not null then
-              jsonb_build_object(
-                'operator', first_operator
-                , 'operands', jsonb_build_array(key, split_part(value, '.', 2))
-              )
-            else
-              jsonb_build_object(
-                'operator', 'invalid_operator'
-                , 'operands', '[]'::jsonb
-              )
-          end
-        ), '[]'::jsonb)
-      )
-    from comparisons 
-    where key not in ('select', 'order')
+        select
+            *
+        from
+            unnest(params)
+            with ordinality r (param, index)
+),
+comparisons as (
+select
+    lower(columns.param) as key,
+    values.param as value,
+    omni_rest.postgrest_convert_operator (split_part(values.param, '.', 1)) as first_operator,
+    omni_rest.postgrest_convert_operator (split_part(values.param, '.', 2)) as second_operator
+from
+    indexed_params columns
+    join indexed_params
+values
+    on columns.index % 2 = 1
+        and values.index % 2 = 0
+        and columns.index = values.index - 1
+)
+select
+    jsonb_build_object('operator', 'and', 'operands', coalesce(jsonb_agg(
+                case when key = 'not.and' then
+                    jsonb_build_object('operator', 'not', 'operands', jsonb_build_array(jsonb_build_object('operator', 'and', 'operands', omni_rest.postgrest_parse_logical (value))))
+                when key = 'and' then
+                    jsonb_build_object('operator', 'and', 'operands', omni_rest.postgrest_parse_logical (value))
+                when key = 'not.or' then
+                    jsonb_build_object('operator', 'not', 'operands', jsonb_build_array(jsonb_build_object('operator', 'or', 'operands', omni_rest.postgrest_parse_logical (value))))
+                when key = 'or' then
+                    jsonb_build_object('operator', 'or', 'operands', omni_rest.postgrest_parse_logical (value))
+                when first_operator = 'not' then
+                    jsonb_build_object('operator', 'not', 'operands', jsonb_build_array(jsonb_build_object('operator', second_operator, 'operands', jsonb_build_array(key, split_part(value, '.', 3)))))
+                when first_operator is not null then
+                    jsonb_build_object('operator', first_operator, 'operands', jsonb_build_array(key, split_part(value, '.', 2)))
+                else
+                    jsonb_build_object('operator', 'invalid_operator', 'operands', '[]'::jsonb)
+                end), '[]'::jsonb))
+from
+    comparisons
+where
+    key not in ('select', 'order')
 $$;
 
-create function postgrest_format_get_param(where_ast jsonb) returns text
-    immutable
-    language plpgsql as
-$$
+create function postgrest_format_get_param (where_ast jsonb)
+    returns text immutable
+    language plpgsql
+    as $$
 declare
-  output text;
+    output text;
 begin
-    select 
-        case where_ast->>'operator'
-          when 'invalid_operator' then
+    select
+        case where_ast ->> 'operator'
+        when 'invalid_operator' then
             'invalid_operator invalid_operator'
-          when 'not' then
-            format(
-              'not (%1$s)',
-              omni_rest.postgrest_format_get_param(where_ast->'operands'->0)
-            )
-          when 'and' then
-            (
-              select 
-                    string_agg(
-                          omni_rest.postgrest_format_get_param(op), ' and '
-                    )
-              from jsonb_array_elements(where_ast->'operands') op
-            )
-          when 'or' then
-            (
-              select 
-                    string_agg(
-                          omni_rest.postgrest_format_get_param(op), ' or '
-                    )
-              from jsonb_array_elements(where_ast->'operands') op
-            )
-          else
-            format(
-              '%1$I %2$s %3$L',
-              where_ast->'operands'->>0,
-              where_ast->>'operator',
-              where_ast->'operands'->>1
-            )
-        end
-    into output;
-
+        when 'not' then
+            format('not (%1$s)', omni_rest.postgrest_format_get_param (where_ast -> 'operands' -> 0))
+        when 'and' then
+        (
+            select
+                string_agg(omni_rest.postgrest_format_get_param (op), ' and ')
+            from
+                jsonb_array_elements(where_ast -> 'operands') op)
+        when 'or' then
+        (
+            select
+                string_agg(omni_rest.postgrest_format_get_param (op), ' or ')
+            from
+                jsonb_array_elements(where_ast -> 'operands') op)
+    else
+        format('%1$I %2$s %3$L', where_ast -> 'operands' ->> 0, where_ast ->> 'operator', where_ast -> 'operands' ->> 1)
+        end into output;
     return output;
 end;
 $$;
@@ -339,53 +279,41 @@ begin
     _where := omni_rest.postgrest_format_get_param(omni_rest.postgrest_parse_get_param(params));
 
     _offset := 0;
-
-    select 'ORDER BY ' || string_agg(format(
-      '%1$I %2$s'
-      , split_part(o, '.', 1)
-      -- FIXME: we should error instead of using a default on invalid ordering clauses
-      , CASE lower(split_part(o, '.', 2)) WHEN 'desc' THEN 'desc' ELSE 'asc' END
-    ), ',') 
-    from unnest(regexp_split_to_array(omni_web.param_get(params, 'order'), ',')) o
-    into _order;
-
+    select
+        'ORDER BY ' || string_agg(format('%1$I %2$s', split_part(o, '.', 1),
+                -- FIXME: we should error instead of using a default on invalid ordering clauses
+                case lower(split_part(o, '.', 2))
+                when 'desc' then
+                    'desc'
+                else
+                    'asc'
+                end), ',')
+    from
+        unnest(regexp_split_to_array(omni_web.param_get (params, 'order'), ',')) o into _order;
     -- Finalize the query
-    query := format(
-      'select %3$s from %1$I.%2$I where %4$s %5$s'
-      , namespace
-      , (select relname from pg_class where oid = relation)
-      , concat_ws(', ', variadic query_columns)
-      , coalesce(_where, 'true')
-      , _order
-    );
-
+    query := format('select %3$s from %1$I.%2$I where %4$s %5$s', namespace, (
+            select
+                relname
+            from pg_class
+            where
+                oid = relation), concat_ws(', ', variadic query_columns), coalesce(_where, 'true'), _order);
     -- Run it
     declare
       message text;
       detail text;
       hint text;
     begin
-      select coalesce(jsonb_agg(stmt_row), '[]'::jsonb)
-      into result
-      from omni_sql.execute(query);
-
-      outcome := omni_httpd.http_response(
-        result
-        , headers => array [omni_http.http_header('Content-Range', _offset || '-' || jsonb_array_length(result) ||'/*')]
-      );
+        select
+            coalesce(jsonb_agg(stmt_row), '[]'::jsonb) into result
+        from
+            omni_sql.execute (query);
+        outcome := omni_httpd.http_response (result, headers => array[omni_http.http_header ('Content-Range', _offset || '-' || jsonb_array_length(result) || '/*')]);
     exception
-      when others then
-        get stacked diagnostics message = message_text,
-                                detail = pg_exception_detail,
-                                hint = pg_exception_hint;
-        outcome := omni_httpd.http_response(
-          jsonb_build_object(
-            'message', message
-            , 'detail', detail
-            , 'hint', hint
-          ),
-          status => 400
-        );
+        when others then
+            get stacked diagnostics message = message_text,
+            detail = pg_exception_detail,
+            hint = pg_exception_hint;
+    outcome := omni_httpd.http_response (jsonb_build_object('message', message, 'detail', detail, 'hint', hint), status => 400);
     end;
 
 end;

--- a/extensions/omni_rest/src/postgrest_get.sql
+++ b/extensions/omni_rest/src/postgrest_get.sql
@@ -70,6 +70,12 @@ begin
                 result := result || case lower(current_production)
                 when '' then
                     omni_rest.postgrest_parse_logical (current)
+                when 'or' then
+                    jsonb_build_object('operator', 'or', 'operands', omni_rest.postgrest_parse_logical (current))
+                when 'and' then
+                    jsonb_build_object('operator', 'and', 'operands', omni_rest.postgrest_parse_logical (current))
+                when 'not.or' then
+                    jsonb_build_object('operator', 'not', 'operands', jsonb_build_array(jsonb_build_object('operator', 'or', 'operands', omni_rest.postgrest_parse_logical (current))))
                 when 'not.and' then
                     jsonb_build_object('operator', 'not', 'operands', jsonb_build_array(jsonb_build_object('operator', 'and', 'operands', omni_rest.postgrest_parse_logical (current))))
                 when 'not' then

--- a/extensions/omni_rest/src/postgrest_get.sql
+++ b/extensions/omni_rest/src/postgrest_get.sql
@@ -135,10 +135,30 @@ $$
         'operator', 'and'
         , 'operands', coalesce(jsonb_agg(
           case
+            when key = 'not.and' then
+              jsonb_build_object(
+                'operator', 'not'
+                , 'operands', jsonb_build_array( 
+                  jsonb_build_object(
+                    'operator', 'and'
+                    , 'operands', omni_rest.postgrest_parse_logical(value)
+                  )
+                )
+              )
             when key = 'and' then
               jsonb_build_object(
                 'operator', 'and'
                 , 'operands', omni_rest.postgrest_parse_logical(value)
+              )
+            when key = 'not.or' then
+              jsonb_build_object(
+                'operator', 'not'
+                , 'operands', jsonb_build_array( 
+                  jsonb_build_object(
+                    'operator', 'or'
+                    , 'operands', omni_rest.postgrest_parse_logical(value)
+                  )
+                )
               )
             when key = 'or' then
               jsonb_build_object(

--- a/extensions/omni_rest/src/postgrest_get.sql
+++ b/extensions/omni_rest/src/postgrest_get.sql
@@ -114,8 +114,8 @@ begin
       when 'like' THEN 'like' 
       when 'ilike' THEN 'ilike' 
       when 'match' THEN '~' 
-      when 'imatch' THEN '~*' 
-
+      when 'imatch' THEN '~*'
+      else 'invalid_operator'
       end as operator, 
       split_part(values.param, '.', 2) as value
     from 

--- a/extensions/omni_rest/src/postgrest_get.sql
+++ b/extensions/omni_rest/src/postgrest_get.sql
@@ -146,9 +146,9 @@ begin
       );
     exception
       when others then
-        GET STACKED DIAGNOSTICS message = MESSAGE_TEXT,
-                                detail = PG_EXCEPTION_DETAIL,
-                                hint = PG_EXCEPTION_HINT;
+        get stacked diagnostics message = message_text,
+                                detail = pg_exception_detail,
+                                hint = pg_exception_hint;
         outcome := omni_httpd.http_response(
           jsonb_build_object(
             'message', message

--- a/extensions/omni_rest/tests/get-horizontal-filtering.yml
+++ b/extensions/omni_rest/tests/get-horizontal-filtering.yml
@@ -1,0 +1,113 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  config:
+    shared_preload_libraries: */env/OMNI_SO
+    max_worker_processes: 64
+  init:
+  - set session omni_httpd.init_port = 0
+  - create extension omni_httpd cascade
+  - create extension omni_httpc cascade
+  # FIXME: waiting for two reloads is working around a startup bug in omni_httpd
+  - call omni_httpd.wait_for_configuration_reloads(2)
+  - create extension omni_rest cascade
+  - create schema app
+  - create schema app1
+  - |
+    create
+        or
+        replace function omni_httpd.handler(int, omni_httpd.http_request) returns omni_httpd.http_outcome
+        language plpgsql
+    as
+    $$
+    declare
+        req omni_httpd.http_request;
+        resp omni_httpd.http_outcome;
+    begin
+        req := $2;
+        call omni_rest.postgrest(req, resp, omni_rest.postgrest_settings(schemas => '{app, app1}'));
+        if resp is not distinct from null then
+            resp := omni_httpd.http_response(status => 404);
+        end if;
+        return resp;
+    end;
+    $$
+  - |
+    create function make_request(path text, headers omni_http.http_headers default array []::omni_http.http_headers, method omni_http.http_method default 'GET') returns setof omni_httpc.http_response
+        language sql as
+    $$
+    select *
+    from omni_httpc.http_execute(
+            omni_httpc.http_request('http://127.0.0.1:' ||
+                                    (select effective_port from omni_httpd.listeners) ||
+                                    path, headers => headers, method => method))
+    $$
+  - |
+    create table app.users
+    (
+        id           serial primary key,
+        name         text,
+        email        text,
+        profile_info jsonb
+    )
+  - insert into app.users (id, name, email)
+    values (1, 'John Doe', 'john@doe.com')
+  - insert into app.users (id, name, email)
+    values (2, 'Jane Doe', 'jane@doe.com')
+
+tests:
+
+- name: Error case for filtering on non existing attributte
+  query: |
+    with response as (select * from make_request('/users?non_existing=eq.1'))
+    select response.status,
+           (select json_agg(json_build_object(h.name, h.value))
+            from unnest(response.headers) h
+            where h.name not in ('server', 'content-length', 'connection')) as headers,
+           convert_from(response.body, 'utf-8')::json                       as body
+    from response
+  results:
+  - status: 400
+    headers:
+    - content-type: application/json
+    body:
+     hint: ""
+     detail: ""
+     message: "column \"non_existing\" does not exist"
+
+- name: Empty result
+  query: |
+    with response as (select * from make_request('/users?id=eq.3'))
+    select response.status,
+           (select json_agg(json_build_object(h.name, h.value))
+            from unnest(response.headers) h
+            where h.name not in ('server', 'content-length', 'connection')) as headers,
+           convert_from(response.body, 'utf-8')::json                       as body
+    from response
+  results:
+  - status: 200
+    headers:
+    - content-range: 0-0/*
+    - content-type: application/json
+    body: []
+
+- name: Equality operator
+  query: |
+    with response as (select * from make_request('/users?id=eq.1'))
+    select response.status,
+           (select json_agg(json_build_object(h.name, h.value))
+            from unnest(response.headers) h
+            where h.name not in ('server', 'content-length', 'connection')) as headers,
+           convert_from(response.body, 'utf-8')::json                       as body
+    from response
+  results:
+  - status: 200
+    headers:
+    - content-range: 0-1/*
+    - content-type: application/json
+    body:
+    - id: 1
+      name: John Doe
+      email: john@doe.com
+      profile_info: null
+
+          

--- a/extensions/omni_rest/tests/get-horizontal-filtering.yml
+++ b/extensions/omni_rest/tests/get-horizontal-filtering.yml
@@ -393,3 +393,39 @@ tests:
       email: john@doe.com
       profile_info: null
 
+- name: Logical not.and operator
+  query: |
+    with response as (select * from make_request('/users?not.and=(id.eq.1,name.imatch.doe)'))
+    select response.status,
+           (select json_agg(json_build_object(h.name, h.value))
+            from unnest(response.headers) h
+            where h.name not in ('server', 'content-length', 'connection')) as headers,
+           convert_from(response.body, 'utf-8')::json                       as body
+    from response
+  results:
+  - status: 200
+    headers:
+    - content-range: 0-1/*
+    - content-type: application/json
+    body:
+    - id: 2
+      name: Jane Doe
+      email: jane@doe.com
+      profile_info: null
+
+- name: Logical not.or operator
+  query: |
+    with response as (select * from make_request('/users?not.or=(id.eq.1,name.imatch.doe)'))
+    select response.status,
+           (select json_agg(json_build_object(h.name, h.value))
+            from unnest(response.headers) h
+            where h.name not in ('server', 'content-length', 'connection')) as headers,
+           convert_from(response.body, 'utf-8')::json                       as body
+    from response
+  results:
+  - status: 200
+    headers:
+    - content-range: 0-0/*
+    - content-type: application/json
+    body: []
+

--- a/extensions/omni_rest/tests/get-horizontal-filtering.yml
+++ b/extensions/omni_rest/tests/get-horizontal-filtering.yml
@@ -56,6 +56,24 @@ instance:
 
 tests:
 
+- name: Error case for invalid operator
+  query: |
+    with response as (select * from make_request('/users?id=non_existing_operator.1'))
+    select response.status,
+           (select json_agg(json_build_object(h.name, h.value))
+            from unnest(response.headers) h
+            where h.name not in ('server', 'content-length', 'connection')) as headers,
+           convert_from(response.body, 'utf-8')::json                       as body
+    from response
+  results:
+  - status: 400
+    headers:
+    - content-type: application/json
+    body:
+     hint: ""
+     detail: ""
+     message: "syntax error at or near \"invalid_operator\""
+
 - name: Error case for filtering on non existing attributte
   query: |
     with response as (select * from make_request('/users?non_existing=eq.1'))

--- a/extensions/omni_rest/tests/get-horizontal-filtering.yml
+++ b/extensions/omni_rest/tests/get-horizontal-filtering.yml
@@ -328,3 +328,48 @@ tests:
       name: Jane Doe
       email: jane@doe.com
       profile_info: null
+
+- name: Logical not operator
+  query: |
+    with response as (select * from make_request('/users?id=not.eq.1'))
+    select response.status,
+           (select json_agg(json_build_object(h.name, h.value))
+            from unnest(response.headers) h
+            where h.name not in ('server', 'content-length', 'connection')) as headers,
+           convert_from(response.body, 'utf-8')::json                       as body
+    from response
+  results:
+  - status: 200
+    headers:
+    - content-range: 0-1/*
+    - content-type: application/json
+    body:
+    - id: 2
+      name: Jane Doe
+      email: jane@doe.com
+      profile_info: null
+
+- name: Logical or operator
+  query: |
+    with response as (select * from make_request('/users?or=(id.eq.1,id.eq.2)'))
+    select response.status,
+           (select json_agg(json_build_object(h.name, h.value))
+            from unnest(response.headers) h
+            where h.name not in ('server', 'content-length', 'connection')) as headers,
+           convert_from(response.body, 'utf-8')::json                       as body
+    from response
+  results:
+  - status: 200
+    headers:
+    - content-range: 0-2/*
+    - content-type: application/json
+    body:
+    - id: 1
+      name: John Doe
+      email: john@doe.com
+      profile_info: null
+    - id: 2
+      name: Jane Doe
+      email: jane@doe.com
+      profile_info: null
+

--- a/extensions/omni_rest/tests/get-horizontal-filtering.yml
+++ b/extensions/omni_rest/tests/get-horizontal-filtering.yml
@@ -130,7 +130,7 @@ tests:
       email: john@doe.com
       profile_info: null
 
-- name: Inequality operators
+- name: Inequality operators (lt & gt)
   query: |
     with response as (select * from make_request('/users?id=gt.1&name=lt.John+Doe'))
     select response.status,
@@ -150,5 +150,31 @@ tests:
       email: jane@doe.com
       profile_info: null
 
+- name: Inequality operators (lte & gte)
+  query: |
+    with response as (select * from make_request('/users?id=gte.1&name=lte.John+Doe&order=id'))
+    select response.status,
+           (select json_agg(json_build_object(h.name, h.value))
+            from unnest(response.headers) h
+            where h.name not in ('server', 'content-length', 'connection')) as headers,
+           convert_from(response.body, 'utf-8')::json                       as body
+    from response
+  results:
+  - status: 200
+    headers:
+    - content-range: 0-2/*
+    - content-type: application/json
+    body:
+    - id: 1
+      name: John Doe
+      email: john@doe.com
+      profile_info: null
+    - id: 2
+      name: Jane Doe
+      email: jane@doe.com
+      profile_info: null
+
+          
+          
           
           

--- a/extensions/omni_rest/tests/get-horizontal-filtering.yml
+++ b/extensions/omni_rest/tests/get-horizontal-filtering.yml
@@ -130,6 +130,46 @@ tests:
       email: john@doe.com
       profile_info: null
 
+- name: Not equal
+  query: |
+    with response as (select * from make_request('/users?id=neq.1'))
+    select response.status,
+           (select json_agg(json_build_object(h.name, h.value))
+            from unnest(response.headers) h
+            where h.name not in ('server', 'content-length', 'connection')) as headers,
+           convert_from(response.body, 'utf-8')::json                       as body
+    from response
+  results:
+  - status: 200
+    headers:
+    - content-range: 0-1/*
+    - content-type: application/json
+    body:
+    - id: 2
+      name: Jane Doe
+      email: jane@doe.com
+      profile_info: null
+
+- name: Is distinct from
+  query: |
+    with response as (select * from make_request('/users?id=isdistinct.1'))
+    select response.status,
+           (select json_agg(json_build_object(h.name, h.value))
+            from unnest(response.headers) h
+            where h.name not in ('server', 'content-length', 'connection')) as headers,
+           convert_from(response.body, 'utf-8')::json                       as body
+    from response
+  results:
+  - status: 200
+    headers:
+    - content-range: 0-1/*
+    - content-type: application/json
+    body:
+    - id: 2
+      name: Jane Doe
+      email: jane@doe.com
+      profile_info: null
+
 - name: Inequality operators (lt & gt)
   query: |
     with response as (select * from make_request('/users?id=gt.1&name=lt.John+Doe'))
@@ -175,6 +215,98 @@ tests:
       profile_info: null
 
           
-          
-          
-          
+- name: Like operator
+  query: |
+    with response as (select * from make_request('/users?name=like.%Doe%&order=id'))
+    select response.status,
+           (select json_agg(json_build_object(h.name, h.value))
+            from unnest(response.headers) h
+            where h.name not in ('server', 'content-length', 'connection')) as headers,
+           convert_from(response.body, 'utf-8')::json                       as body
+    from response
+  results:
+  - status: 200
+    headers:
+    - content-range: 0-2/*
+    - content-type: application/json
+    body:
+    - id: 1
+      name: John Doe
+      email: john@doe.com
+      profile_info: null
+    - id: 2
+      name: Jane Doe
+      email: jane@doe.com
+      profile_info: null
+
+- name: Ilike operator
+  query: |
+    with response as (select * from make_request('/users?name=ilike.%doe%&order=id'))
+    select response.status,
+           (select json_agg(json_build_object(h.name, h.value))
+            from unnest(response.headers) h
+            where h.name not in ('server', 'content-length', 'connection')) as headers,
+           convert_from(response.body, 'utf-8')::json                       as body
+    from response
+  results:
+  - status: 200
+    headers:
+    - content-range: 0-2/*
+    - content-type: application/json
+    body:
+    - id: 1
+      name: John Doe
+      email: john@doe.com
+      profile_info: null
+    - id: 2
+      name: Jane Doe
+      email: jane@doe.com
+      profile_info: null
+
+- name: Match operator
+  query: |
+    with response as (select * from make_request('/users?name=match.Doe&order=id'))
+    select response.status,
+           (select json_agg(json_build_object(h.name, h.value))
+            from unnest(response.headers) h
+            where h.name not in ('server', 'content-length', 'connection')) as headers,
+           convert_from(response.body, 'utf-8')::json                       as body
+    from response
+  results:
+  - status: 200
+    headers:
+    - content-range: 0-2/*
+    - content-type: application/json
+    body:
+    - id: 1
+      name: John Doe
+      email: john@doe.com
+      profile_info: null
+    - id: 2
+      name: Jane Doe
+      email: jane@doe.com
+      profile_info: null
+
+- name: Imatch operator
+  query: |
+    with response as (select * from make_request('/users?name=imatch.doe&order=id'))
+    select response.status,
+           (select json_agg(json_build_object(h.name, h.value))
+            from unnest(response.headers) h
+            where h.name not in ('server', 'content-length', 'connection')) as headers,
+           convert_from(response.body, 'utf-8')::json                       as body
+    from response
+  results:
+  - status: 200
+    headers:
+    - content-range: 0-2/*
+    - content-type: application/json
+    body:
+    - id: 1
+      name: John Doe
+      email: john@doe.com
+      profile_info: null
+    - id: 2
+      name: Jane Doe
+      email: jane@doe.com
+      profile_info: null

--- a/extensions/omni_rest/tests/get-horizontal-filtering.yml
+++ b/extensions/omni_rest/tests/get-horizontal-filtering.yml
@@ -130,4 +130,25 @@ tests:
       email: john@doe.com
       profile_info: null
 
+- name: Inequality operators
+  query: |
+    with response as (select * from make_request('/users?id=gt.1&name=lt.John+Doe'))
+    select response.status,
+           (select json_agg(json_build_object(h.name, h.value))
+            from unnest(response.headers) h
+            where h.name not in ('server', 'content-length', 'connection')) as headers,
+           convert_from(response.body, 'utf-8')::json                       as body
+    from response
+  results:
+  - status: 200
+    headers:
+    - content-range: 0-1/*
+    - content-type: application/json
+    body:
+    - id: 2
+      name: Jane Doe
+      email: jane@doe.com
+      profile_info: null
+
+          
           

--- a/extensions/omni_rest/tests/get-horizontal-filtering.yml
+++ b/extensions/omni_rest/tests/get-horizontal-filtering.yml
@@ -373,3 +373,23 @@ tests:
       email: jane@doe.com
       profile_info: null
 
+- name: Logical and operator
+  query: |
+    with response as (select * from make_request('/users?and=(id.eq.1,name.imatch.doe)'))
+    select response.status,
+           (select json_agg(json_build_object(h.name, h.value))
+            from unnest(response.headers) h
+            where h.name not in ('server', 'content-length', 'connection')) as headers,
+           convert_from(response.body, 'utf-8')::json                       as body
+    from response
+  results:
+  - status: 200
+    headers:
+    - content-range: 0-1/*
+    - content-type: application/json
+    body:
+    - id: 1
+      name: John Doe
+      email: john@doe.com
+      profile_info: null
+

--- a/extensions/omni_rest/tests/get-horizontal-filtering.yml
+++ b/extensions/omni_rest/tests/get-horizontal-filtering.yml
@@ -110,4 +110,24 @@ tests:
       email: john@doe.com
       profile_info: null
 
+- name: Multiple comparisons
+  query: |
+    with response as (select * from make_request('/users?id=eq.1&name=eq.John+Doe'))
+    select response.status,
+           (select json_agg(json_build_object(h.name, h.value))
+            from unnest(response.headers) h
+            where h.name not in ('server', 'content-length', 'connection')) as headers,
+           convert_from(response.body, 'utf-8')::json                       as body
+    from response
+  results:
+  - status: 200
+    headers:
+    - content-range: 0-1/*
+    - content-type: application/json
+    body:
+    - id: 1
+      name: John Doe
+      email: john@doe.com
+      profile_info: null
+
           

--- a/extensions/omni_rest/tests/get-horizontal-filtering.yml
+++ b/extensions/omni_rest/tests/get-horizontal-filtering.yml
@@ -429,3 +429,26 @@ tests:
     - content-type: application/json
     body: []
 
+- name: Logical operator nesting
+  query: |
+    with response as (select * from make_request('/users?order=id&or=(or(id.eq.1,id.eq.2),not.or(id.eq.1,name.imatch.doe))'))
+    select response.status,
+           (select json_agg(json_build_object(h.name, h.value))
+            from unnest(response.headers) h
+            where h.name not in ('server', 'content-length', 'connection')) as headers,
+           convert_from(response.body, 'utf-8')::json                       as body
+    from response
+  results:
+  - status: 200
+    headers:
+    - content-range: 0-2/*
+    - content-type: application/json
+    body:
+    - id: 1
+      name: John Doe
+      email: john@doe.com
+      profile_info: null
+    - id: 2
+      name: Jane Doe
+      email: jane@doe.com
+      profile_info: null


### PR DESCRIPTION
So far this PR Implements a simple equality, empty result and an error case.

The goal is to implement at least all simple operators on for [horizontal filtering described in the PostgREST docs](https://docs.postgrest.org/en/v12/references/api/tables_views.html#horizontal-filtering).

We might want to leave logical operators and modifiers for another PR (or even another release).

This is just a very rough draft for early feedback so we can align on the approach and any code style issues.

## Some technical decisions so far

* Surface the underlying database error details to keep the interface as similar to PostgREST.
Bellow is a similar PostgREST request trying to filter for a non-existing field
![image](https://github.com/user-attachments/assets/2a120a48-bbc8-44ab-a312-c2221d5ba156)
* Split the horizontal filtering tests into a separate yaml since there are going to be several test cases and we can benefit from a separate setup and more fine grained test output.