### PR TITLE
Initial RPC support

### DIFF
--- a/extensions/omni_rest/migrate/1_postgrest.sql
+++ b/extensions/omni_rest/migrate/1_postgrest.sql
@@ -6,9 +6,11 @@ create type postgrest_settings as
 
 /*{% include "../src/postgrest_settings.sql" %}*/
 /*{% include "../src/_postgrest_relation.sql" %}*/
+/*{% include "../src/_postgrest_function.sql" %}*/
 
 /*{% include "../src/__eval.sql" %}*/
 /*{% include "../src/postgrest_get.sql" %}*/
+/*{% include "../src/postgrest_rpc.sql" %}*/
 /*{% include "../src/postgrest_insert.sql" %}*/
 /*{% include "../src/postgrest_cors.sql" %}*/
 /*{% include "../src/postgrest.sql" %}*/

--- a/extensions/omni_rest/src/_postgrest_function.sql
+++ b/extensions/omni_rest/src/_postgrest_function.sql
@@ -1,0 +1,35 @@
+create procedure _postgrest_function (request omni_httpd.http_request, function_name inout regproc, namespace inout text, settings postgrest_settings default postgrest_settings ())
+language plpgsql
+as $$
+declare
+    saved_search_path text := current_setting('search_path');
+begin
+    if request.method = 'GET' then
+        namespace := omni_http.http_header_get (request.headers, 'accept-profile');
+    end if;
+    if request.method = 'POST' then
+        namespace := omni_http.http_header_get (request.headers, 'content-profile');
+    end if;
+    if namespace is null and cardinality(settings.schemas) > 0 then
+        namespace := settings.schemas[1]::text;
+    end if;
+    if namespace is null then
+        return;
+    end if;
+    if not namespace::name = any (settings.schemas) then
+        function_name := null;
+        namespace := null;
+        return;
+    end if;
+    perform
+        set_config('search_path', namespace, true);
+    function_name := to_regproc (split_part(request.path, '/', 3));
+    if function_name is null or function_name::text like 'pg_%' then
+        function_name := null;
+        return;
+    end if;
+    perform
+        set_config('search_path', saved_search_path, false);
+end;
+$$;
+

--- a/extensions/omni_rest/src/_postgrest_function.sql
+++ b/extensions/omni_rest/src/_postgrest_function.sql
@@ -45,8 +45,7 @@ declare
 begin
     if request.method = 'GET' then
         namespace := omni_http.http_header_get (request.headers, 'accept-profile');
-    end if;
-    if request.method = 'POST' then
+    else
         namespace := omni_http.http_header_get (request.headers, 'content-profile');
     end if;
     if namespace is null and cardinality(settings.schemas) > 0 then

--- a/extensions/omni_rest/src/_postgrest_function.sql
+++ b/extensions/omni_rest/src/_postgrest_function.sql
@@ -1,8 +1,47 @@
-create procedure _postgrest_function (request omni_httpd.http_request, function_name inout regproc, namespace inout text, settings postgrest_settings default postgrest_settings ())
+create or replace function _postgrest_function_by_arguments (namespace text, function_name text, function_arguments text[])
+    returns regproc[]
+    language sql
+    stable
+    as $$
+    with arguments as (
+        select
+            oid,
+            array_agg(coalesce(name, '')) filter (where idx <= (pronargs - pronargdefaults)) as required_parameters,
+        array_agg(coalesce(name, '')) as parameters
+    from
+        pg_proc,
+        unnest(proargnames, proargtypes, proargmodes)
+        with ordinality as _ (name, type, mode, idx)
+    where
+        type is not null -- only input arguments
+    group by
+        oid
+        -- we can only work with named arguments
+    having
+        count(*) - count(name) = 0
+)
+select
+    array_agg(p.oid::regproc)
+from
+    pg_proc p
+    left join arguments a on a.oid = p.oid
+    left join pg_catalog.pg_namespace n on n.oid = p.pronamespace
+where
+    n.nspname = namespace
+    and p.proname = function_name
+    and coalesce(required_parameters, '{}') <@ function_arguments
+    and (function_arguments <@ coalesce(parameters, '{}')
+        or function_arguments = coalesce(parameters, '{}'))
+$$;
+
+create procedure _postgrest_function (request omni_httpd.http_request, function_reference inout regproc, namespace inout text, settings postgrest_settings default postgrest_settings ())
 language plpgsql
 as $$
 declare
     saved_search_path text := current_setting('search_path');
+    function_name text;
+    function_arguments text[];
+    all_references regproc[];
 begin
     if request.method = 'GET' then
         namespace := omni_http.http_header_get (request.headers, 'accept-profile');
@@ -17,15 +56,36 @@ begin
         return;
     end if;
     if not namespace::name = any (settings.schemas) then
-        function_name := null;
+        function_reference := null;
         namespace := null;
         return;
     end if;
     perform
         set_config('search_path', namespace, true);
-    function_name := to_regproc (split_part(request.path, '/', 3));
-    if function_name is null or function_name::text like 'pg_%' then
-        function_name := null;
+    function_name := split_part(request.path, '/', 3);
+    select
+        case request.method
+        when 'GET' then
+        (
+            select
+                array_agg(name)
+            from
+                unnest(omni_web.parse_query_string (request.query_string))
+                with ordinality as _ (name, i)
+            where
+                i % 2 = 1)
+        when 'POST' then
+        (
+            select
+                array_agg(jsonb_object_keys)
+            from
+                jsonb_object_keys(convert_from(request.body, 'utf-8')::jsonb))
+        end into function_arguments;
+    all_references := omni_rest._postgrest_function_by_arguments (namespace, function_name, coalesce(function_arguments, '{}'));
+    select
+        all_references[1] into function_reference;
+    if function_reference is null or function_reference::text like 'pg_%' then
+        function_reference := null;
         return;
     end if;
     perform

--- a/extensions/omni_rest/src/postgrest.sql
+++ b/extensions/omni_rest/src/postgrest.sql
@@ -5,6 +5,7 @@ as
 $$
 declare
 begin
+    call omni_rest.postgrest_rpc(request, response, settings);
     call omni_rest.postgrest_get(request, response, settings);
     call omni_rest.postgrest_insert(request, response, settings);
     call omni_rest.postgrest_cors(request, response, settings);

--- a/extensions/omni_rest/src/postgrest_get.sql
+++ b/extensions/omni_rest/src/postgrest_get.sql
@@ -42,7 +42,6 @@ declare
     current_production text := '';
     depth int := 0;
     token text;
-    sublist text[];
 begin
     -- no nesting, just split and return
     if input !~ '[()]' then

--- a/extensions/omni_rest/src/postgrest_rpc.sql
+++ b/extensions/omni_rest/src/postgrest_rpc.sql
@@ -2,7 +2,7 @@ create procedure postgrest_rpc (request omni_httpd.http_request, outcome inout o
 language plpgsql
 as $$
 declare
-    function_name regproc;
+    function_reference regproc;
     query text;
     namespace text;
     result jsonb;
@@ -15,8 +15,8 @@ begin
         if split_part(request.path, '/', 2) <> 'rpc' then
             return;
         end if;
-        call omni_rest._postgrest_function (request, function_name, namespace, settings);
-        if function_name is null then
+        call omni_rest._postgrest_function (request, function_reference, namespace, settings);
+        if function_reference is null then
             return;
             -- terminate
         end if;
@@ -24,7 +24,7 @@ begin
         return;
         -- terminate;
     end if;
-    query := format('select %1$s() as result', function_name);
+    query := format('select %1$s() as result', function_reference);
     -- Run it
     declare message text;
     detail text;

--- a/extensions/omni_rest/src/postgrest_rpc.sql
+++ b/extensions/omni_rest/src/postgrest_rpc.sql
@@ -1,0 +1,46 @@
+create procedure postgrest_rpc (request omni_httpd.http_request, outcome inout omni_httpd.http_outcome, settings postgrest_settings default postgrest_settings ())
+language plpgsql
+as $$
+declare
+    function_name regproc;
+    query text;
+    namespace text;
+    result jsonb;
+begin
+    if outcome is distinct from null then
+        return;
+    end if;
+    if request.method in ('GET', 'POST') then
+        -- FIXME: write guard clause checking for function
+        if split_part(request.path, '/', 2) <> 'rpc' then
+            return;
+        end if;
+        call omni_rest._postgrest_function (request, function_name, namespace, settings);
+        if function_name is null then
+            return;
+            -- terminate
+        end if;
+    else
+        return;
+        -- terminate;
+    end if;
+    query := format('select %1$s() as result', function_name);
+    -- Run it
+    declare message text;
+    detail text;
+    hint text;
+    begin
+        select
+            omni_sql.execute (query) -> 'result' into result;
+        outcome := omni_httpd.http_response (result);
+    exception
+        when others then
+            get stacked diagnostics message = message_text,
+            detail = pg_exception_detail,
+            hint = pg_exception_hint;
+    outcome := omni_httpd.http_response (jsonb_build_object('message', message, 'detail', detail, 'hint', hint), status => 400);
+    end;
+end;
+
+$$;
+

--- a/extensions/omni_rest/src/postgrest_rpc.sql
+++ b/extensions/omni_rest/src/postgrest_rpc.sql
@@ -1,3 +1,20 @@
+create or replace function _postgrest_function_call_arguments (fn regproc, passed_arguments text[])
+    returns text immutable
+    language sql
+    as $$
+    select
+        string_agg(format('%1$I => $%2$s :: %3$I', name, idx, t.typname), ', ')
+    from
+        pg_proc p,
+        unnest(proargnames, proargtypes, proargmodes)
+    with ordinality as _ (name, type, mode, idx)
+    join pg_type t on t.oid = type
+where
+    type is not null
+    and p.oid = fn
+    and name::text = any (passed_arguments)
+$$;
+
 create procedure postgrest_rpc (request omni_httpd.http_request, outcome inout omni_httpd.http_outcome, settings postgrest_settings default postgrest_settings ())
 language plpgsql
 as $$
@@ -6,6 +23,9 @@ declare
     query text;
     namespace text;
     result jsonb;
+    arguments_definition text;
+    argument_values jsonb;
+    passed_arguments text[];
 begin
     if outcome is distinct from null then
         return;
@@ -24,14 +44,52 @@ begin
         return;
         -- terminate;
     end if;
-    query := format('select %1$s() as result', function_reference);
+    select
+        case request.method
+        when 'GET' then
+        (
+            select
+                array_agg(name)
+            from
+                unnest(omni_web.parse_query_string (request.query_string))
+                with ordinality as _ (name, i)
+            where
+                i % 2 = 1)
+        when 'POST' then
+        (
+            select
+                array_agg(jsonb_object_keys)
+            from
+                jsonb_object_keys(convert_from(request.body, 'utf-8')::jsonb))
+        end into passed_arguments;
+    arguments_definition := coalesce(omni_rest._postgrest_function_call_arguments (function_reference, passed_arguments), '');
+    query := format('select %1$s(%2$s) as result', function_reference, arguments_definition);
+    select
+        case request.method
+        when 'GET' then
+        (
+            select
+                jsonb_agg(value::text)
+            from
+                unnest(omni_web.parse_query_string (request.query_string))
+                with ordinality as _ (value, i)
+            where
+                i % 2 = 0)
+        when 'POST' then
+        (
+            select
+                jsonb_agg(v)
+            from
+                jsonb_each_text(convert_from(request.body, 'utf-8')::jsonb) as _ (k,
+                    v))
+        end into argument_values;
     -- Run it
     declare message text;
     detail text;
     hint text;
     begin
         select
-            omni_sql.execute (query) -> 'result' into result;
+            omni_sql.execute (query, coalesce(argument_values, '[]'::jsonb)) -> 'result' into result;
         outcome := omni_httpd.http_response (result);
     exception
         when others then
@@ -41,6 +99,5 @@ begin
     outcome := omni_httpd.http_response (jsonb_build_object('message', message, 'detail', detail, 'hint', hint), status => 400);
     end;
 end;
-
 $$;
 

--- a/extensions/omni_rest/src/postgrest_rpc.sql
+++ b/extensions/omni_rest/src/postgrest_rpc.sql
@@ -49,7 +49,6 @@ begin
         return;
     end if;
     if request.method in ('GET', 'POST') then
-        -- FIXME: write guard clause checking for function
         if split_part(request.path, '/', 2) <> 'rpc' then
             return;
         end if;

--- a/extensions/omni_rest/tests/rpc.yml
+++ b/extensions/omni_rest/tests/rpc.yml
@@ -68,3 +68,11 @@ tests:
     headers:
     - content-type: application/json
     body: "pong"
+
+- name: No match when adding spurious parameters
+  query: |
+    with response as (select * from make_request('/rpc/ping?non_existing_parameter=true'))
+    select response.status
+    from response
+  results:
+  - status: 404

--- a/extensions/omni_rest/tests/rpc.yml
+++ b/extensions/omni_rest/tests/rpc.yml
@@ -1,0 +1,70 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  config:
+    shared_preload_libraries: */env/OMNI_SO
+    max_worker_processes: 64
+  init:
+  - set session omni_httpd.init_port = 0
+  - create extension omni_httpd cascade
+  - create extension omni_httpc cascade
+  # FIXME: waiting for two reloads is working around a startup bug in omni_httpd
+  - call omni_httpd.wait_for_configuration_reloads(2)
+  - create extension omni_rest cascade
+  - create schema app
+  - |
+    create
+        or
+        replace function omni_httpd.handler(int, omni_httpd.http_request) returns omni_httpd.http_outcome
+        language plpgsql
+    as
+    $$
+    declare
+        req omni_httpd.http_request;
+        resp omni_httpd.http_outcome;
+    begin
+        req := $2;
+        call omni_rest.postgrest(req, resp, omni_rest.postgrest_settings(schemas => '{app}'));
+        if resp is not distinct from null then
+            resp := omni_httpd.http_response(status => 404);
+        end if;
+        return resp;
+    end;
+    $$
+  - |
+    create function make_request(path text, headers omni_http.http_headers default array []::omni_http.http_headers, method omni_http.http_method default 'GET') returns setof omni_httpc.http_response
+        language sql as
+    $$
+    select *
+    from omni_httpc.http_execute(
+            omni_httpc.http_request('http://127.0.0.1:' ||
+                                    (select effective_port from omni_httpd.listeners) ||
+                                    path, headers => headers, method => method))
+    $$
+  - |
+    create function app.ping() returns text language sql as $$ SELECT 'pong'; $$;
+    
+
+tests:
+
+- name: Error case for function not found
+  query: |
+    with response as (select * from make_request('/rpc/non_existing_function'))
+    select response.status
+    from response
+  results:
+  - status: 404
+
+- name: Single text result
+  query: |
+    with response as (select * from make_request('/rpc/ping'))
+    select response.status,
+           (select json_agg(json_build_object(h.name, h.value))
+            from unnest(response.headers) h
+            where h.name in ('content-type')) as headers,
+           convert_from(response.body, 'utf-8')::json                       as body
+    from response
+  results:
+  - status: 200
+    headers:
+    - content-type: application/json
+    body: "pong"

--- a/extensions/omni_rest/tests/rpc.yml
+++ b/extensions/omni_rest/tests/rpc.yml
@@ -52,6 +52,10 @@ instance:
     create table app.users (email text primary key, name text not null);
   - |
     create function app.side_effect() returns void language sql as $$ insert into app.users values (gen_random_uuid() || '@bar.com', 'foobar'); $$;
+  - |
+    create function app.return_composite() returns app.users language sql as $$ select * from (values ('john@doe.com', 'John Doe')); $$;
+  - |
+    create function app.srf() returns setof app.users language sql as $$ select * from (values ('jane@doe.com', 'Jane Doe'), ('john@doe.com', 'John Doe')); $$;
 
 tests:
 
@@ -189,3 +193,77 @@ tests:
     from response
   results:
   - status: 200
+
+- name: Return composite values from GET
+  query: |
+    with response as (select * from make_request('/rpc/return_composite'))
+    select response.status,
+           (select json_agg(json_build_object(h.name, h.value))
+            from unnest(response.headers) h
+            where h.name in ('content-type')) as headers,
+           convert_from(response.body, 'utf-8')::json                       as body
+    from response
+  results:
+  - status: 200
+    headers:
+    - content-type: application/json
+    body: 
+      name: "John Doe"
+      email: "john@doe.com"
+
+- name: Return composite values from POST
+  query: |
+    with response as (select * from make_request('/rpc/return_composite', method => 'POST', body => '{}'))
+    select response.status,
+           (select json_agg(json_build_object(h.name, h.value))
+            from unnest(response.headers) h
+            where h.name in ('content-type')) as headers,
+           convert_from(response.body, 'utf-8')::json                       as body
+    from response
+  results:
+  - status: 200
+    headers:
+    - content-type: application/json
+    body: 
+      name: "John Doe"
+      email: "john@doe.com"
+
+- name: Return set of values from GET
+  query: |
+    with response as (select * from make_request('/rpc/srf'))
+    select response.status,
+           (select json_agg(json_build_object(h.name, h.value))
+            from unnest(response.headers) h
+            where h.name in ('content-type', 'content-range')) as headers,
+           convert_from(response.body, 'utf-8')::json                       as body
+    from response
+  results:
+  - status: 200
+    headers:
+    - content-range: 0-2/*
+    - content-type: application/json
+    body:
+    - name: Jane Doe
+      email: jane@doe.com
+    - name: John Doe
+      email: john@doe.com
+
+- name: Return set of values from POST
+  query: |
+    with response as (select * from make_request('/rpc/srf', method => 'POST', body => '{}'))
+    select response.status,
+           (select json_agg(json_build_object(h.name, h.value))
+            from unnest(response.headers) h
+            where h.name in ('content-type', 'content-range')) as headers,
+           convert_from(response.body, 'utf-8')::json                       as body
+    from response
+  results:
+  - status: 200
+    headers:
+    - content-range: 0-2/*
+    - content-type: application/json
+    body:
+    - name: Jane Doe
+      email: jane@doe.com
+    - name: John Doe
+      email: john@doe.com

--- a/extensions/omni_rest/tests/rpc.yml
+++ b/extensions/omni_rest/tests/rpc.yml
@@ -48,6 +48,10 @@ instance:
     create function app.two_or_three_parameters(a int, b text) returns text language sql as $$ SELECT format('int %1$L and text %2$L and optional missing', a, b); $$;
   - |
     create function app.two_or_three_parameters(a int, b text, c text default 'three') returns text language sql as $$ SELECT format('int %1$L and text %2$L and optional %3$L', a, b, c); $$;
+  - |
+    create table app.users (email text primary key, name text not null);
+  - |
+    create function app.side_effect() returns void language sql as $$ insert into app.users values (gen_random_uuid() || '@bar.com', 'foobar'); $$;
 
 tests:
 
@@ -159,3 +163,22 @@ tests:
     headers:
     - content-type: application/json
     body: "int '1' and text 'two' and optional 'three'"
+
+- name: Try to execute function with side effects in a GET request
+  query: |
+    with response as (select * from make_request('/rpc/side_effect'))
+    select response.status,
+           (select json_agg(json_build_object(h.name, h.value))
+            from unnest(response.headers) h
+            where h.name in ('content-type')) as headers,
+           convert_from(response.body, 'utf-8')::json                       as body
+    from response
+  results:
+  - status: 400
+    headers:
+    - content-type: application/json
+    body: 
+      hint: ""
+      detail: ""
+      message: "cannot execute INSERT in a read-only transaction"
+

--- a/extensions/omni_rest/tests/rpc.yml
+++ b/extensions/omni_rest/tests/rpc.yml
@@ -42,7 +42,8 @@ instance:
     $$
   - |
     create function app.ping() returns text language sql as $$ SELECT 'pong'; $$;
-    
+  - |
+    create function app.two_parameters(a int, b text) returns text language sql as $$ SELECT format('int %1$L and text %2$L', a, b); $$;
 
 tests:
 
@@ -76,3 +77,18 @@ tests:
     from response
   results:
   - status: 404
+
+- name: Two mandatory parameters
+  query: |
+    with response as (select * from make_request('/rpc/two_parameters?a=1&b=two'))
+    select response.status,
+           (select json_agg(json_build_object(h.name, h.value))
+            from unnest(response.headers) h
+            where h.name in ('content-type')) as headers,
+           convert_from(response.body, 'utf-8')::json                       as body
+    from response
+  results:
+  - status: 200
+    headers:
+    - content-type: application/json
+    body: "int '1' and text 'two'"

--- a/extensions/omni_rest/tests/rpc.yml
+++ b/extensions/omni_rest/tests/rpc.yml
@@ -182,3 +182,10 @@ tests:
       detail: ""
       message: "cannot execute INSERT in a read-only transaction"
 
+- name: Try to execute function with side effects in a POST request
+  query: |
+    with response as (select * from make_request('/rpc/side_effect', method => 'POST', body => '{}'))
+    select response.status
+    from response
+  results:
+  - status: 200

--- a/extensions/omni_rest/tests/rpc.yml
+++ b/extensions/omni_rest/tests/rpc.yml
@@ -31,15 +31,15 @@ instance:
     end;
     $$
   - |
-    create function make_request(path text, headers omni_http.http_headers default array []::omni_http.http_headers, method omni_http.http_method default 'GET') returns setof omni_httpc.http_response
+      create function make_request(path text, headers omni_http.http_headers default array []::omni_http.http_headers, method omni_http.http_method default 'GET', body jsonb default null::jsonb) returns setof omni_httpc.http_response
         language sql as
-    $$
-    select *
-    from omni_httpc.http_execute(
-            omni_httpc.http_request('http://127.0.0.1:' ||
-                                    (select effective_port from omni_httpd.listeners) ||
-                                    path, headers => headers, method => method))
-    $$
+      $$
+      select *
+      from omni_httpc.http_execute(
+              omni_httpc.http_request('http://127.0.0.1:' ||
+                                      (select effective_port from omni_httpd.listeners) ||
+      path, headers => headers, method => method, body => convert_to(body::text, 'utf8')))
+      $$
   - |
     create function app.ping() returns text language sql as $$ SELECT 'pong'; $$;
   - |
@@ -139,6 +139,21 @@ tests:
             where h.name in ('content-type')) as headers,
            convert_from(response.body, 'utf-8')::json                       as body
     from response
+  results:
+  - status: 200
+    headers:
+    - content-type: application/json
+    body: "int '1' and text 'two' and optional 'three'"
+
+- name: Two mandatory parameters and one optional in a POST request
+  query: |
+      with response as (select * from make_request('/rpc/two_or_three_parameters', method => 'POST', body => '{"b": "two", "a": 1, "c": "three"}'))
+      select response.status,
+             (select json_agg(json_build_object(h.name, h.value))
+              from unnest(response.headers) h
+              where h.name in ('content-type')) as headers,
+             convert_from(response.body, 'utf-8')::json                       as body
+      from response
   results:
   - status: 200
     headers:

--- a/extensions/omni_rest/tests/rpc.yml
+++ b/extensions/omni_rest/tests/rpc.yml
@@ -44,6 +44,10 @@ instance:
     create function app.ping() returns text language sql as $$ SELECT 'pong'; $$;
   - |
     create function app.two_parameters(a int, b text) returns text language sql as $$ SELECT format('int %1$L and text %2$L', a, b); $$;
+  - |
+    create function app.two_or_three_parameters(a int, b text) returns text language sql as $$ SELECT format('int %1$L and text %2$L and optional missing', a, b); $$;
+  - |
+    create function app.two_or_three_parameters(a int, b text, c text default 'three') returns text language sql as $$ SELECT format('int %1$L and text %2$L and optional %3$L', a, b, c); $$;
 
 tests:
 
@@ -92,3 +96,51 @@ tests:
     headers:
     - content-type: application/json
     body: "int '1' and text 'two'"
+
+- name: Two mandatory parameters and one optional missing when function is overloaded
+  query: |
+    with response as (select * from make_request('/rpc/two_or_three_parameters?a=1&b=two'))
+    select response.status,
+           (select json_agg(json_build_object(h.name, h.value))
+            from unnest(response.headers) h
+            where h.name in ('content-type')) as headers,
+           convert_from(response.body, 'utf-8')::json                       as body
+    from response
+  results:
+  - status: 400
+    headers:
+    - content-type: application/json
+    body:
+      hint: "Could not choose a best candidate function. You might need to add explicit type casts."
+      detail: ""
+      message: "function app.two_or_three_parameters(a => integer, b => text) is not unique"
+
+- name: Two mandatory parameters and one optional passed when function is overloaded
+  query: |
+    with response as (select * from make_request('/rpc/two_or_three_parameters?a=1&b=two&c=three'))
+    select response.status,
+           (select json_agg(json_build_object(h.name, h.value))
+            from unnest(response.headers) h
+            where h.name in ('content-type')) as headers,
+           convert_from(response.body, 'utf-8')::json                       as body
+    from response
+  results:
+  - status: 200
+    headers:
+    - content-type: application/json
+    body: "int '1' and text 'two' and optional 'three'"
+
+- name: Two mandatory parameters and one optional passed out of order when function is overloaded
+  query: |
+    with response as (select * from make_request('/rpc/two_or_three_parameters?b=two&a=1&c=three'))
+    select response.status,
+           (select json_agg(json_build_object(h.name, h.value))
+            from unnest(response.headers) h
+            where h.name in ('content-type')) as headers,
+           convert_from(response.body, 'utf-8')::json                       as body
+    from response
+  results:
+  - status: 200
+    headers:
+    - content-type: application/json
+    body: "int '1' and text 'two' and optional 'three'"


### PR DESCRIPTION
The goal is to implement a subset of the RPC endpoints functionality as [described in PostgREST docs](https://docs.postgrest.org/en/v12/references/api/functions.html).

This PR will implement the basic funcionality of identifying and calling functions through GET or POST requests.
It also should detect if the result is a list of scalar value and format the response accordingly.

## What this PR will not cover
* any filtering (vertical or horizontal) of the results
* functions-with-an-array-of-json-objects
* functions-with-a-single-unnamed-json-parameter
* functions-with-array-parameters
* variadic-functions