### PR TITLE
Execute Update for PATCH endpoints 

### DIFF
--- a/extensions/omni_rest/migrate/1_postgrest.sql
+++ b/extensions/omni_rest/migrate/1_postgrest.sql
@@ -12,5 +12,6 @@ create type postgrest_settings as
 /*{% include "../src/postgrest_get.sql" %}*/
 /*{% include "../src/postgrest_rpc.sql" %}*/
 /*{% include "../src/postgrest_insert.sql" %}*/
+/*{% include "../src/postgrest_update.sql" %}*/
 /*{% include "../src/postgrest_cors.sql" %}*/
 /*{% include "../src/postgrest.sql" %}*/

--- a/extensions/omni_rest/src/_postgrest_relation.sql
+++ b/extensions/omni_rest/src/_postgrest_relation.sql
@@ -13,7 +13,7 @@ begin
         namespace := omni_http.http_header_get(request.headers, 'accept-profile');
     end if;
 
-    if request.method = 'POST' then
+    if request.method in ('POST', 'PATCH') then
         namespace := omni_http.http_header_get(request.headers, 'content-profile');
     end if;
 

--- a/extensions/omni_rest/src/postgrest.sql
+++ b/extensions/omni_rest/src/postgrest.sql
@@ -8,6 +8,7 @@ begin
     call omni_rest.postgrest_rpc(request, response, settings);
     call omni_rest.postgrest_get(request, response, settings);
     call omni_rest.postgrest_insert(request, response, settings);
+    call omni_rest.postgrest_update(request, response, settings);
     call omni_rest.postgrest_cors(request, response, settings);
 end;
 $$;

--- a/extensions/omni_rest/src/postgrest_get.sql
+++ b/extensions/omni_rest/src/postgrest_get.sql
@@ -183,6 +183,89 @@ begin
 end;
 $$;
 
+/*
+ * Given a namespace, reference to a relation and a text of comma separated field names
+ * It returns an array of expressions to be used for vertical filtering.
+ */
+create function postgrest_select_columns (namespace text, relation regclass, _select text)
+    returns text[] immutable
+    language plpgsql
+    as $$
+declare
+    query_columns   text[] := array ['*'];
+    col             text;
+begin
+    if _select is not null and _select <> '' then
+        query_columns := array []::text[];
+
+
+        foreach col in array string_to_array(_select, ',')
+        loop
+
+            declare
+                col_name    text;
+                col_expr    text;
+                col_alias   text;
+                _match      text[];
+                is_col_name bool;
+            begin
+                col_expr := split_part(col, ':', 1);
+                col_alias := split_part(col, ':', 2);
+
+                _match := regexp_match(col_expr, '^([[:alpha:] _][[:alnum:] _]*)(.*)');
+                col_name := _match[1];
+                if col_name is null then
+                    raise exception 'no column specified in %', col_expr;
+                end if;
+
+                -- Check if there is such an attribute
+                perform from pg_attribute where attname = col_name and attrelid = relation and attnum > 0;
+                is_col_name := found;
+                -- If not...
+                if not is_col_name then
+                    -- Is it a function?
+                    perform
+                    from pg_proc
+                    where proargtypes[0] = relation
+                      and proname = col_name
+                      and pronamespace::text = namespace;
+                    if found then
+                        -- It is a function
+                        col_name := col_name || '((' || relation || '))';
+                    end if;
+                end if;
+                col_expr := col_name || _match[2];
+
+                if col_alias = '' then
+                    col_alias := col_expr;
+                end if;
+                if col_expr ~ '->' then
+                    -- Handle JSON expression
+                    if col_alias = col_expr then
+                        -- Update the alias if it was not set
+                        with arr as (select regexp_split_to_array(col_expr, '->>?') as data)
+                        select data[cardinality(data)]
+                        from arr
+                        into col_alias;
+                    end if;
+                    -- Rewrite the expression to match its actual syntax
+                    col_expr :=
+                            regexp_replace(col_expr, '(->>?)([[:alpha:]_][[:alnum:]_]*)(?=(->|$))', '\1''\2''',
+                                           'g');
+                    -- TODO: record access using ->
+                end if;
+                -- TODO: sanitize col_expr
+                query_columns := query_columns || (relation || '.' || col_expr || ' as "' || col_alias || '"');
+
+
+            end;
+        end loop;
+
+    end if;
+    return query_columns;
+end;
+$$;
+
 create procedure postgrest_get(request omni_httpd.http_request, outcome inout omni_httpd.http_outcome,
                                settings postgrest_settings default postgrest_settings())
     language plpgsql as
@@ -190,6 +273,7 @@ $$
 declare
     namespace text;
     query_columns   text[];
+    new_query_columns   text[];
     query     text;
     result   jsonb;
     params    text[];
@@ -217,76 +301,11 @@ begin
                      encode(digest(relation || ' ' || coalesce(request.query_string, ''), 'sha256'), 'hex');
     query := omni_var.get_session(request_cache, null::text);
     if query is null then
-
         params := omni_web.parse_query_string(request.query_string);
 
         -- Columns (vertical filtering)
-        query_columns := array ['*'];
-
         _select = omni_web.param_get(params, 'select');
-
-        if _select is not null and _select != '' then
-            query_columns := array []::text[];
-
-            foreach col in array string_to_array(_select, ',')
-                loop
-                    declare
-                        col_name    text;
-                        col_expr    text;
-                        col_alias   text;
-                        _match      text[];
-                        is_col_name bool;
-                    begin
-                        col_expr := split_part(col, ':', 1);
-                        col_alias := split_part(col, ':', 2);
-
-                        _match := regexp_match(col_expr, '^([[:alpha:] _][[:alnum:] _]*)(.*)');
-                        col_name := _match[1];
-                        if col_name is null then
-                            raise exception 'no column specified in %', col_expr;
-                        end if;
-
-                        -- Check if there is such an attribute
-                        perform from pg_attribute where attname = col_name and attrelid = relation and attnum > 0;
-                        is_col_name := found;
-                        -- If not...
-                        if not is_col_name then
-                            -- Is it a function?
-                            perform
-                            from pg_proc
-                            where proargtypes[0] = relation
-                              and proname = col_name
-                              and pronamespace::text = namespace;
-                            if found then
-                                -- It is a function
-                                col_name := col_name || '((' || relation || '))';
-                            end if;
-                        end if;
-                        col_expr := col_name || _match[2];
-
-                        if col_alias = '' then
-                            col_alias := col_expr;
-                        end if;
-                        if col_expr ~ '->' then
-                            -- Handle JSON expression
-                            if col_alias = col_expr then
-                                -- Update the alias if it was not set
-                                with arr as (select regexp_split_to_array(col_expr, '->>?') as data)
-                                select data[cardinality(data)]
-                                from arr
-                                into col_alias;
-                            end if;
-                            -- Rewrite the expression to match its actual syntax
-                            col_expr :=
-                                    regexp_replace(col_expr, '(->>?)([[:alpha:]_][[:alnum:]_]*)(?=(->|$))', '\1''\2''',
-                                                   'g');
-                            -- TODO: record access using ->
-                        end if;
-                        -- TODO: sanitize col_expr
-                        query_columns := query_columns || (relation || '.' || col_expr || ' as "' || col_alias || '"');
-                    end;
-                end loop;
-        end if;
+        query_columns := omni_rest.postgrest_select_columns(namespace, relation, _select);
 
         _where := omni_rest.postgrest_format_get_param(omni_rest.postgrest_parse_get_param(params));
 

--- a/extensions/omni_rest/src/postgrest_get.sql
+++ b/extensions/omni_rest/src/postgrest_get.sql
@@ -141,7 +141,7 @@ select
                 when first_operator = 'not' then
                     jsonb_build_object('operator', 'not', 'operands', jsonb_build_array(jsonb_build_object('operator', second_operator, 'operands', jsonb_build_array(key, split_part(value, '.', 3)))))
                 when first_operator is not null then
-                    jsonb_build_object('operator', first_operator, 'operands', jsonb_build_array(key, split_part(value, '.', 2)))
+                    jsonb_build_object('operator', first_operator, 'operands', jsonb_build_array(key, (regexp_match(value, '\.(.*)'))[1]))
                 else
                     jsonb_build_object('operator', 'invalid_operator', 'operands', '[]'::jsonb)
                 end), '[]'::jsonb))

--- a/extensions/omni_rest/src/postgrest_update.sql
+++ b/extensions/omni_rest/src/postgrest_update.sql
@@ -1,0 +1,145 @@
+/*
+ * Given a relation reference and an array of argument names,
+ * it builds a string with placeholders for each argument cast to its type.
+ * The placeholders are in the order of the relation definition.
+ * This can be used with _postgrest_update_ordered_field_values to build a SQL command that will update the referenced relation.
+ */ 
+create or replace function _postgrest_update_fields(relation regclass, passed_arguments text[])
+    returns text
+    immutable
+    language sql
+as
+$$
+select 
+    string_agg(format('%1$I = $%2$s :: %3$I', a.attname, pa.idx, t.typname), ', ' order by pa.idx)
+from 
+    pg_attribute a
+    join pg_type t on a.atttypid = t.oid
+    join unnest(passed_arguments) with ordinality as pa (name, idx) on pa.name = a.attname
+where 
+    a.attrelid = relation
+    and a.attname = any (passed_arguments)
+    and a.attnum > 0
+    and not a.attisdropped;
+$$;
+
+/*
+ * Given an array of argument names and a jsonb object in the shape of {[argument_name]:argument_value},
+ * it returns a jsonb array with the argument values in the same order as the array inn passed_arguments.
+ * This can be used with postgrest_update_fields to build a SQL update command
+ */ 
+create or replace function _postgrest_update_ordered_field_values(passed_arguments text[], passed_values jsonb)
+    returns jsonb
+    immutable
+    language sql
+as
+$$
+select 
+    jsonb_agg(passed_values ->> (name::text) order by idx)
+from 
+     unnest(passed_arguments) with ordinality as _ (name, idx);
+$$;
+
+
+create procedure postgrest_update (request omni_httpd.http_request, outcome inout omni_httpd.http_outcome, settings postgrest_settings default postgrest_settings ())
+language plpgsql
+as $$
+declare
+    namespace text;
+    query text;
+    result jsonb;
+    relation regclass;
+    preference text;
+    _missing text;
+    _return text := 'minimal';
+    _tx text;
+    payload jsonb;
+begin
+    if outcome is distinct from null then
+        return;
+    end if;
+    if request.method = 'PATCH' then
+        call omni_rest._postgrest_relation (request, relation, namespace, settings);
+        if relation is null then
+            return;
+            -- terminate
+        end if;
+    else
+        return;
+        -- terminate;
+    end if;
+
+    -- change this when we implement other content types
+    if omni_http.http_header_get (request.headers, 'content-type') <> 'application/json' then
+        outcome := omni_httpd.http_response (status => 501, body => 'Only JSON content type is currently implemented');
+        return;
+    end if;
+
+    -- while we support only json content type we can check its shape here
+    payload := convert_from(request.body, 'utf8')::jsonb;
+    if jsonb_typeof(payload) <> 'object' then
+        outcome := omni_httpd.http_response (status => 422, body => 'Body must be object');
+        return;
+    end if;
+
+    for preference in
+        select regexp_split_to_table(omni_http.http_header_get (request.headers, 'prefer'), ',\s+')
+    loop
+        declare 
+            preference_name text := split_part(preference, '=', 1);
+            preference_value text := split_part(preference, '=', 2);
+        begin
+            case when preference_name = 'missing' then
+                _missing := preference_value;
+            when preference_name = 'return' then
+                _return := preference_value;
+            when preference_name = 'tx' then
+                _tx := preference_value;
+            end case;
+        end;
+    end loop;
+    declare
+        arguments_definition text;
+        argument_values    jsonb;
+        passed_arguments   text[];
+    begin
+        select 
+            array_agg(jsonb_object_keys)
+        from
+            jsonb_object_keys(payload)
+        into passed_arguments;
+        arguments_definition :=
+            coalesce(omni_rest._postgrest_update_fields(relation, passed_arguments), '');
+        argument_values := omni_rest._postgrest_update_ordered_field_values(passed_arguments, payload);
+
+        query := 
+            format('update %1$I.%2$I set %3$s %4$s', 
+                namespace, 
+                (select
+                    relname
+                from pg_class
+                where
+                    oid = relation), 
+                arguments_definition,
+                case when _return = 'representation' then
+                    'returning *'
+                else
+                    ''
+                end
+            );
+        select
+            jsonb_agg(stmt_row)
+        from
+            omni_sql.execute (query, coalesce(argument_values, '[]'::jsonb))
+        into result;
+        if lower(_tx) = 'rollback' then
+            rollback and chain;
+        end if;
+        outcome := omni_httpd.http_response (
+            status => 201, body => case when _return = 'representation' then result end
+        );
+    end;
+end;
+$$;
+
+

--- a/extensions/omni_rest/tests/get-horizontal-filtering.yml
+++ b/extensions/omni_rest/tests/get-horizontal-filtering.yml
@@ -452,3 +452,23 @@ tests:
       name: Jane Doe
       email: jane@doe.com
       profile_info: null
+
+- name: Filter by value containing a dot '.'
+  query: |
+    with response as (select * from make_request('/users?email=eq.john@doe.com'))
+    select response.status,
+           (select json_agg(json_build_object(h.name, h.value))
+            from unnest(response.headers) h
+            where h.name not in ('server', 'content-length', 'connection')) as headers,
+           convert_from(response.body, 'utf-8')::json                       as body
+    from response
+  results:
+  - status: 200
+    headers:
+    - content-range: 0-1/*
+    - content-type: application/json
+    body:
+    - id: 1
+      name: John Doe
+      email: john@doe.com
+      profile_info: null

--- a/extensions/omni_rest/tests/update.yml
+++ b/extensions/omni_rest/tests/update.yml
@@ -1,0 +1,93 @@
+$schema: "https://raw.githubusercontent.com/omnigres/omnigres/master/pg_yregress/schema.json"
+instance:
+  config:
+    shared_preload_libraries: */env/OMNI_SO
+    max_worker_processes: 64
+  init:
+  - set session omni_httpd.init_port = 0
+  - create extension omni_httpd cascade
+  - create extension omni_httpc cascade
+  # FIXME: waiting for two reloads is working around a startup bug in omni_httpd
+  - call omni_httpd.wait_for_configuration_reloads(2)
+  - create extension omni_rest cascade
+  - create schema app
+  - create schema app1
+  - |
+    create
+        or
+        replace function omni_httpd.handler(int, omni_httpd.http_request) returns omni_httpd.http_outcome
+        language plpgsql
+    as
+    $$
+    declare
+        req  omni_httpd.http_request;
+        resp omni_httpd.http_outcome;
+    begin
+        req := $2;
+        raise notice '%', req;
+        call omni_rest.postgrest(req, resp, omni_rest.postgrest_settings(schemas => '{app,app1}'));
+        if resp is not distinct from null then
+            resp := omni_httpd.http_response(status => 404);
+        end if;
+        return resp;
+    end;
+    $$
+  - |
+    create table app.users
+    (
+        id           serial primary key,
+        name         text,
+        email        text,
+        profile_info jsonb
+    )
+  - |
+    create table app1.users
+    (
+        id       serial primary key,
+        username text
+    )
+  - |
+    create function make_request(path text, headers omni_http.http_headers default array []::omni_http.http_headers,
+                                 method omni_http.http_method default 'GET',
+                                 body text default null) returns setof omni_httpc.http_response
+        language sql as
+    $$
+    select *
+    from omni_httpc.http_execute(
+            omni_httpc.http_request('http://127.0.0.1:' ||
+                                    (select effective_port from omni_httpd.listeners) ||
+                                    path, method => method, headers => headers, body => convert_to(body, 'utf8')))
+    $$
+
+tests:
+
+- name: simple JSON update
+  transaction: false
+  steps:
+  - query: insert into app.users values (default, 'John Doe', 'john@doe.com', '{}');
+  - query: |
+      with response as (select *
+                        from make_request('/users?email=john@doe.com', method => 'PATCH',
+                                          headers =>
+                                              array [omni_http.http_header('content-type', 'application/json')],
+                                          body =>
+                                                      jsonb_build_object('name',
+                                                                         'New Name',
+                                                                         'email',
+                                                                         'new@email.com'
+                                                                         )::text
+                                                      ))
+      select response.status
+      from response
+    results:
+    - status: 201
+  - query: select name, email, profile_info
+           from app.users
+    results:
+    - name: New Name
+      email: new@email.com
+      profile_info: {}
+  - name: cleanup
+    query: delete
+           from app.users
+

--- a/extensions/omni_rest/tests/update.yml
+++ b/extensions/omni_rest/tests/update.yml
@@ -195,3 +195,33 @@ tests:
   - name: cleanup
     query: delete from app.users
 
+- name: tx-end rollback
+  transaction: false
+  steps:
+  - query: insert into app.users values ('1', 'John Doe', 'john@doe.com', '{}');
+  - query: |
+      with response as (select *
+                        from make_request('/users', method => 'PATCH',
+                                          headers =>
+                                              array [
+                                                  omni_http.http_header('content-type', 'application/json'),
+                                                  omni_http.http_header('prefer', 'tx=rollback')
+                                          ],
+                                          body =>
+                                                      jsonb_build_object('name',
+                                                                         'New Name',
+                                                                         'email',
+                                                                         'new@email.com'
+                                                                         )::text
+                                                      ))
+      select response.status
+      from response
+    results:
+    - status: 201
+  - query: select name
+           from app.users
+            where name = 'New Name'
+    results: [ ]
+  - name: cleanup
+    query: delete from app.users
+

--- a/extensions/omni_rest/tests/update.yml
+++ b/extensions/omni_rest/tests/update.yml
@@ -241,3 +241,32 @@ tests:
             where name = 'New Name'
     results: [ ]
 
+- name: vertical filtering
+  transaction: false
+  steps:
+  - query: truncate app.users
+  - query: insert into app.users values ('1', 'John Doe', 'john@doe.com', '{}');
+  - query: |
+      with response as (select *
+                        from make_request('/users?select=name', method => 'PATCH',
+                                          headers =>
+                                              array [
+                                                  omni_http.http_header('content-type', 'application/json'),
+                                                  omni_http.http_header('prefer', 'return=representation')
+                                          ],
+                                          body =>
+                                                      jsonb_build_object('name',
+                                                                         'New Name',
+                                                                         'email',
+                                                                         'new@email.com'
+                                                                         )::text
+                                                      ))
+      select 
+          response.status,
+          convert_from(response.body, 'utf8')::jsonb as body
+      from response
+    results:
+    - status: 201
+      body:
+      - name: New Name
+

--- a/extensions/omni_rest/tests/update.yml
+++ b/extensions/omni_rest/tests/update.yml
@@ -61,7 +61,7 @@ instance:
 
 tests:
 
-- name: simple JSON update
+- name: simple update
   transaction: false
   steps:
   - query: insert into app.users values (default, 'John Doe', 'john@doe.com', '{}');
@@ -161,3 +161,37 @@ tests:
   - name: cleanup
     query: delete
            from app.users
+
+- name: return representation
+  transaction: false
+  steps:
+  - query: insert into app.users values ('1', 'John Doe', 'john@doe.com', '{}');
+  - query: |
+      with response as (select *
+                        from make_request('/users', method => 'PATCH',
+                                          headers =>
+                                              array [
+                                                  omni_http.http_header('content-type', 'application/json'),
+                                                  omni_http.http_header('prefer', 'return=representation')
+                                          ],
+                                          body =>
+                                                      jsonb_build_object('name',
+                                                                         'New Name',
+                                                                         'email',
+                                                                         'new@email.com'
+                                                                         )::text
+                                                      ))
+      select 
+          response.status,
+          convert_from(response.body, 'utf8')::jsonb as body
+      from response
+    results:
+    - status: 201
+      body:
+      - id: 1
+        name: New Name
+        email: new@email.com
+        profile_info: {}
+  - name: cleanup
+    query: delete from app.users
+

--- a/extensions/omni_rest/tests/update.yml
+++ b/extensions/omni_rest/tests/update.yml
@@ -64,6 +64,7 @@ tests:
 - name: simple update
   transaction: false
   steps:
+  - query: truncate app.users
   - query: insert into app.users values (default, 'John Doe', 'john@doe.com', '{}');
   - query: |
       with response as (select *
@@ -87,14 +88,12 @@ tests:
     - name: New Name
       email: new@email.com
       profile_info: {}
-  - name: cleanup
-    query: delete
-           from app.users
 
 - name: Update multiple rows without filters
   transaction: false
   steps:
-  - query: insert into app.users values ('1', 'John Doe', 'john@doe.com', '{}'), ('2', 'Jane Doe', 'jane@doe.com', '{}');
+  - query: truncate app.users
+  - query: insert into app.users values (default, 'John Doe', 'john@doe.com', '{}'), (default, 'Jane Doe', 'jane@doe.com', '{}');
   - query: |
       with response as (select *
                         from make_request('/users', method => 'PATCH',
@@ -111,29 +110,25 @@ tests:
       from response
     results:
     - status: 201
-  - query: select id, name, email, profile_info
+  - query: select name, email, profile_info
            from app.users
            order by id
     results:
-    - id: 1
-      name: New Name
+    - name: New Name
       email: new@email.com
       profile_info: {}
-    - id: 2 
-      name: New Name
+    - name: New Name
       email: new@email.com
       profile_info: {}
-  - name: cleanup
-    query: delete
-           from app.users
 
 - name: Update with filter
   transaction: false
   steps:
-  - query: insert into app.users values ('1', 'John Doe', 'john@doe.com', '{}'), ('2', 'Jane Doe', 'jane@doe.com', '{}');
+  - query: truncate app.users
+  - query: insert into app.users values (default, 'John Doe', 'john@doe.com', '{}'), (default, 'Jane Doe', 'jane@doe.com', '{}');
   - query: |
       with response as (select *
-                        from make_request('/users?id=eq.1', method => 'PATCH',
+                        from make_request('/users?name=eq.John+Doe', method => 'PATCH',
                                           headers =>
                                               array [omni_http.http_header('content-type', 'application/json')],
                                           body =>
@@ -147,24 +142,20 @@ tests:
       from response
     results:
     - status: 201
-  - query: select id, name, email, profile_info
+  - query: select name, email, profile_info
            from app.users order by id
     results:
-    - id: 1
-      name: New Name
+    - name: New Name
       email: new@email.com
       profile_info: {}
-    - id: 2 
-      name: Jane Doe
+    - name: Jane Doe
       email: jane@doe.com
       profile_info: {}
-  - name: cleanup
-    query: delete
-           from app.users
 
 - name: return representation
   transaction: false
   steps:
+  - query: truncate app.users
   - query: insert into app.users values ('1', 'John Doe', 'john@doe.com', '{}');
   - query: |
       with response as (select *
@@ -192,13 +183,11 @@ tests:
         name: New Name
         email: new@email.com
         profile_info: {}
-  - name: cleanup
-    query: delete from app.users
-
 - name: tx-end rollback
   transaction: false
   steps:
-  - query: insert into app.users values ('1', 'John Doe', 'john@doe.com', '{}');
+  - query: truncate app.users
+  - query: insert into app.users values (default, 'John Doe', 'john@doe.com', '{}');
   - query: |
       with response as (select *
                         from make_request('/users', method => 'PATCH',
@@ -222,13 +211,12 @@ tests:
            from app.users
             where name = 'New Name'
     results: [ ]
-  - name: cleanup
-    query: delete from app.users
 
-- name: JSON insert into an invalid schema (using headers)
+- name: JSON update table on an invalid schema (using headers)
   transaction: false
   steps:
-  - query: insert into app.users values ('1', 'John Doe', 'john@doe.com', '{}');
+  - query: truncate app.users
+  - query: insert into app.users values (default, 'John Doe', 'john@doe.com', '{}');
   - query: |
       with response as (select *
                         from make_request('/users', method => 'PATCH',
@@ -252,6 +240,4 @@ tests:
            from app.users
             where name = 'New Name'
     results: [ ]
-  - name: cleanup
-    query: delete from app.users
 

--- a/extensions/omni_rest/tests/update.yml
+++ b/extensions/omni_rest/tests/update.yml
@@ -67,7 +67,7 @@ tests:
   - query: insert into app.users values (default, 'John Doe', 'john@doe.com', '{}');
   - query: |
       with response as (select *
-                        from make_request('/users?email=john@doe.com', method => 'PATCH',
+                        from make_request('/users', method => 'PATCH',
                                           headers =>
                                               array [omni_http.http_header('content-type', 'application/json')],
                                           body =>
@@ -127,3 +127,37 @@ tests:
     query: delete
            from app.users
 
+- name: Update with filter
+  transaction: false
+  steps:
+  - query: insert into app.users values ('1', 'John Doe', 'john@doe.com', '{}'), ('2', 'Jane Doe', 'jane@doe.com', '{}');
+  - query: |
+      with response as (select *
+                        from make_request('/users?id=eq.1', method => 'PATCH',
+                                          headers =>
+                                              array [omni_http.http_header('content-type', 'application/json')],
+                                          body =>
+                                                      jsonb_build_object('name',
+                                                                         'New Name',
+                                                                         'email',
+                                                                         'new@email.com'
+                                                                         )::text
+                                                      ))
+      select response.status
+      from response
+    results:
+    - status: 201
+  - query: select id, name, email, profile_info
+           from app.users order by id
+    results:
+    - id: 1
+      name: New Name
+      email: new@email.com
+      profile_info: {}
+    - id: 2 
+      name: Jane Doe
+      email: jane@doe.com
+      profile_info: {}
+  - name: cleanup
+    query: delete
+           from app.users

--- a/extensions/omni_rest/tests/update.yml
+++ b/extensions/omni_rest/tests/update.yml
@@ -225,3 +225,33 @@ tests:
   - name: cleanup
     query: delete from app.users
 
+- name: JSON insert into an invalid schema (using headers)
+  transaction: false
+  steps:
+  - query: insert into app.users values ('1', 'John Doe', 'john@doe.com', '{}');
+  - query: |
+      with response as (select *
+                        from make_request('/users', method => 'PATCH',
+                                          headers =>
+                                              array [
+                                                  omni_http.http_header('content-type', 'application/json'),
+                                                  omni_http.http_header('content-profile', 'public')
+                                          ],
+                                          body =>
+                                                      jsonb_build_object('name',
+                                                                         'New Name',
+                                                                         'email',
+                                                                         'new@email.com'
+                                                                         )::text
+                                                      ))
+      select response.status
+      from response
+    results:
+    - status: 404
+  - query: select name
+           from app.users
+            where name = 'New Name'
+    results: [ ]
+  - name: cleanup
+    query: delete from app.users
+

--- a/extensions/omni_rest/tests/update.yml
+++ b/extensions/omni_rest/tests/update.yml
@@ -91,3 +91,39 @@ tests:
     query: delete
            from app.users
 
+- name: Update multiple rows without filters
+  transaction: false
+  steps:
+  - query: insert into app.users values ('1', 'John Doe', 'john@doe.com', '{}'), ('2', 'Jane Doe', 'jane@doe.com', '{}');
+  - query: |
+      with response as (select *
+                        from make_request('/users', method => 'PATCH',
+                                          headers =>
+                                              array [omni_http.http_header('content-type', 'application/json')],
+                                          body =>
+                                                      jsonb_build_object('name',
+                                                                         'New Name',
+                                                                         'email',
+                                                                         'new@email.com'
+                                                                         )::text
+                                                      ))
+      select response.status
+      from response
+    results:
+    - status: 201
+  - query: select id, name, email, profile_info
+           from app.users
+           order by id
+    results:
+    - id: 1
+      name: New Name
+      email: new@email.com
+      profile_info: {}
+    - id: 2 
+      name: New Name
+      email: new@email.com
+      profile_info: {}
+  - name: cleanup
+    query: delete
+           from app.users
+


### PR DESCRIPTION
This should implement a minimal set of features to do table updates as described in [PostgREST docs](https://docs.postgrest.org/en/v12/references/api/tables_views.html#update).

## Notes

* I have extracted `postgrest_select_columns` that was in place for the `GET` vertical filtering. It works for the test cases we currently have and I believe there will be no distinction between these two cases.
* Form encoded bodies are not supported yet, we trigger a 501 when content types other than application/json are requested.